### PR TITLE
Retarget to labs.moduscreate.com

### DIFF
--- a/features/main.feature
+++ b/features/main.feature
@@ -6,19 +6,20 @@ Feature: Main tests
 @smoke @regression @desktop
 Scenario: Visit the home page
   Given I am on the desktop home page
-  Then I must see the page title "Modus Create - HTML5 Application Development & Training"
-  Given I click the "Services" span
+  Then I must see the page title "Modus Create Labs"
+  When I click the "Cucumber Watir" link
+  Then I wait for the "test harness" text to be displayed
 
 @regression @mobile
 Scenario: Visit the home page on a mobile device
-    Given I am on the desktop home page
-    Then I must see the page title "Modus Create - HTML5 Application Development & Training"
-    Given I click the "icon-reorder" icon
-    And I wait for the menu to be displayed
+  Given I am on the desktop home page
+  Then I must see the page title "Modus Create Labs"
+  When I click the "Cucumber Watir" link
+  Then I wait for the "test harness" text to be displayed
 
 @wip @tablet
 Scenario: Visit the home page on a tablet
   Given I am on the desktop home page
-  Then I must see the page title "Modus Create - HTML5 Application Development & Training"
-  Given I click the "Blog" span
-  Then I must see the page title "Blog | Modus Create"
+  Then I must see the page title "Modus Create Labs"
+  When I click the "Cucumber Watir" link
+  Then I wait for the "test harness" text to be displayed

--- a/features/support/urls.rb
+++ b/features/support/urls.rb
@@ -7,8 +7,8 @@ module Urls
   #TARGET = :Guest
 
   BASE_URL = {
-    :Production  => "http://moduscreate.com/",
-    :Local => "http://localhost:8080/",
+    :Production  => "http://labs.moduscreate.com/",
+    :Local => "http://localhost:4000/",
     :LocalSSL => "https://localhost:8443/",
     :Guest => "http://localhost:80/",
   }
@@ -27,7 +27,7 @@ module Urls
     else
       raise "Can't find mapping from \"#{page_name}\" to a url.\n" +
         "Please add a mapping in #{__FILE__}"
-     end
+    end
   end
 
 end


### PR DESCRIPTION
The recent home page redesign of moduscreate.com broke the test suite.
Let's retarget this vs. labs.moduscreate.com to get something more
stable.

I also rejiggered the Cucumber Given-When-Then to be more in the spirit of https://github.com/cucumber/cucumber/wiki/Given-When-Then